### PR TITLE
15 Add golden opportunity turn

### DIFF
--- a/action/actions.py
+++ b/action/actions.py
@@ -1,11 +1,13 @@
 from action import Action
-from player import Player
 from stock_market.stock import Stock
 from stock_market.stock_market import StockMarket
 from stock_market.transaction import Transaction
+from player import Player
 
-CompleteTransactions = False   #Set CompleteTransactions = True to see other teams transactions as well
-AnonymousTransactions = True   #Set AnonymousTransactions = False to see player name in transaction
+# Set CompleteTransactions = True to see other teams transactions as well
+CompleteTransactions = False
+# Set AnonymousTransactions = False to see player name in transaction
+AnonymousTransactions = True
 
 
 class AllocateToBuyoutFund(Action):
@@ -25,7 +27,7 @@ class BuyStock(Action):
     def run(self) -> None:
         stock_ticker, quantity = self.player.choose_buy_stock(
             self.stock_market)
-        
+
         if stock_ticker is None:
             return
 
@@ -47,8 +49,9 @@ class BuyStock(Action):
         # add stock to portfolio
         portfolio[stock_ticker] += quantity
 
-        #add transaction to market
-        transaction: Transaction = Transaction(self.player, stock, quantity, total_price, True)
+        # add transaction to market
+        transaction: Transaction = Transaction(
+            self.player, stock, quantity, total_price, True)
         self.stock_market.transactions.append(transaction)
 
         print(f"Bought {quantity} shares of {stock_ticker}")
@@ -70,7 +73,10 @@ class CheckBalance(Action):
         self.player: Player = player
 
     def run(self) -> None:
-        print(f"{self.player.name}'s Current Balance: ${self.player.capital:.2f}")
+        print(
+            f"{self.player.name}'s Current Balance: "
+            f"${self.player.capital:.2f}"
+        )
 
 
 class GetStockInfo(Action):
@@ -84,6 +90,7 @@ class GetStockInfo(Action):
         if stock is None:
             return
         stock.printinfo()
+
 
 class GetTransactionHistory(Action):
 
@@ -106,8 +113,8 @@ class GetTransactionHistory(Action):
             if not transaction.buying:
                 action = "sold"
             if (transaction.player.team == self.player.team) or CompleteTransactions:
-                print(f"{indentstr}{player} {action} {transaction.quantity} {share} of {transaction.stock.name} for ${transaction.price:.2f}")
-
+                print(f"{indentstr}{player} {action} {transaction.quantity} "
+                      f"{share} of {transaction.stock.name} for ${transaction.price:.2f}")
 
 
 class SellStock(Action):
@@ -118,9 +125,8 @@ class SellStock(Action):
 
     def run(self) -> None:
 
-        
         stock_name, quantity = self.player.choose_sell_stock(self.stock_market)
-    
+
         if (stock_name is None or quantity is None):
             return
 
@@ -131,7 +137,7 @@ class SellStock(Action):
         total_sale: int = market_value * quantity
         self.player.capital += total_sale
 
-        #Increase stock shares available and marketshares
+        # Increase stock shares available and marketshares
 
         stock.shares += quantity
         stock.owned -= quantity
@@ -143,8 +149,9 @@ class SellStock(Action):
         assert portfolio[stock_name] >= quantity
         portfolio[stock_name] -= quantity
 
-        #add transaction to market
-        transaction: Transaction = Transaction(self.player, stock, quantity, total_sale, False)
+        # add transaction to market
+        transaction: Transaction = Transaction(
+            self.player, stock, quantity, total_sale, False)
         self.stock_market.transactions.append(transaction)
 
         print(f"Sold {quantity} shares of {stock_name}")

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
 from stock_market.stock_market import StockMarket
-from player.real_player import RealPlayer
-from player.ai_player import AiPlayer
 from team import Team
-from turn.build_turn import BuildTurn
+from turn import BuildTurn, GoldenOpportunityTurn, run_turns
+from player.real_player import RealPlayer
+
+NUM_BUILD_TURNS = 5
+NUM_GO_TURNS = 1
 
 if __name__ == "__main__":
     team1 = Team(
@@ -21,14 +23,22 @@ if __name__ == "__main__":
             RealPlayer("Ghost", 10000, 3),
         ])
 
+    teams: list[Team] = [team1, team2]
+
     stock_market = StockMarket()
     stock_market.initialize_stocks()
 
     # Set the market condition to 'recession' for all stocks
     for stock in stock_market.stocks:
-        stock.set_market_condition('Normal')
+        stock.set_market_condition('normal')
 
-    build_turn = BuildTurn([team1, team2], stock_market)
+    build_turn: BuildTurn = BuildTurn(teams, stock_market)
+    go_turn: GoldenOpportunityTurn = GoldenOpportunityTurn(
+        teams, stock_market)
 
-    while True:
-        build_turn.run()
+    turns = [
+        [build_turn, NUM_BUILD_TURNS],
+        [go_turn, NUM_GO_TURNS],
+    ]
+
+    run_turns(turns)

--- a/player/ai_player.py
+++ b/player/ai_player.py
@@ -4,6 +4,7 @@ from stock_market.stock import Stock
 from stock_market.stock_market import StockMarket
 import random
 import time
+from turn.golden_opportunity_turn import GoldenOpportunityStock
 
 
 class AiPlayer(Player):
@@ -95,7 +96,7 @@ class AiPlayer(Player):
 
         return stock_to_sell, amount_to_sell
 
-    def choose_get_info(self, stock_market: StockMarket) -> str:
+    def choose_get_info(self, stock_market: StockMarket) -> Stock:
         stock_market.print_market_status(False)
 
         stocks_dict = stock_market.get_stocks()
@@ -114,3 +115,6 @@ class AiPlayer(Player):
         time.sleep(2)
 
         return stock
+
+    def choose_go_investment_amount(self, go_stock: GoldenOpportunityStock) -> float:
+        raise NotImplementedError

--- a/player/player.py
+++ b/player/player.py
@@ -9,7 +9,7 @@ class Player:
         self.percentage_stake: int = percentage_stake
         self.portfolio: dict = {}  # {stock_name: quantity}
         self.team = None
-    
+
     def setTeam(self, team):
         self.team = team
 
@@ -25,3 +25,6 @@ class Player:
     def choose_sell_stock(self, stock_market: StockMarket) -> tuple[str, int]:
         raise NotImplementedError()
 
+
+def choose_go_investment_amount(self, go_stock) -> float:
+    raise NotImplementedError()

--- a/player/real_player.py
+++ b/player/real_player.py
@@ -2,6 +2,7 @@ from action import Action
 from player import Player
 from stock_market.stock import Stock
 from stock_market.stock_market import StockMarket
+from turn.golden_opportunity_turn import GoldenOpportunityStock
 
 
 class RealPlayer(Player):
@@ -11,7 +12,7 @@ class RealPlayer(Player):
         self.percentage_stake: int = percentage_stake
         self.portfolio: dict[str, int] = {}  # {stock: quantity}
 
-    def check_portfolio(self, stock_market: StockMarket, indent = 2):
+    def check_portfolio(self, stock_market: StockMarket, indent=2):
         print(f"{self.name}'s Portfolio:")
         indentstr = " " * indent
         total = 0
@@ -32,17 +33,22 @@ class RealPlayer(Player):
             if not reachedpenny:
                 print(f"{indentstr}Owned Penny Stocks:")
                 reachedpenny = True
-            print(f"{indentstr}{indentstr}{stock}: {self.portfolio[stock]} shares")
+            print(
+                f"{indentstr}{indentstr}{stock}: "
+                f"{self.portfolio[stock]} shares"
+            )
         for stock in blue:
             if not reachedblue:
                 print(f"{indentstr}Owned Blue Chip Stocks:")
                 reachedblue = True
-            print(f"{indentstr}{indentstr}{stock}: {self.portfolio[stock]} shares")
+            print(
+                f"{indentstr}{indentstr}{stock}: "
+                f"{self.portfolio[stock]} shares"
+            )
         print(f"Total portfolio value: ${total:.2f}")
 
     def choose_action(self, actions: list[Action], indent: int = 0) -> Action:
         indent_str: str = " " * indent
-
         prompt: str = indent_str + "Available Actions:"
 
         for i, action in enumerate(actions):
@@ -90,13 +96,13 @@ class RealPlayer(Player):
                 maxamt = int(self.capital // stock.price)
                 if stock.shares < maxamt:
                     maxamt = stock.shares
-                tmp: str = input(f"Enter the quantity you want to buy (up to {maxamt}) (q to quit): ").strip()
+                tmp: str = input(f"Enter the quantity you want to buy (up to "
+                                 f"{maxamt}) (q to quit): ").strip()
                 try:
                     quantity = int(tmp)
                 except ValueError:
                     if tmp == "q":
                         return [None, None]
-                    print("Quantity shoud be a number.")
                     print("Quantity should be a number.")
                     continue
 
@@ -113,7 +119,8 @@ class RealPlayer(Player):
                 continue
 
             elif quantity > stock.shares:
-                print(f"{stock.ticker} only has {stock.shares} available shares.")
+                print(f"{stock.ticker} only has "
+                      f"{stock.shares} available shares.")
                 continue
 
             return stock_name, quantity
@@ -141,13 +148,15 @@ class RealPlayer(Player):
             quantity_available = self.portfolio.get(stock_name)
 
             quantity: int
-            
+
             if quantity_available is None or quantity_available == 0:
                 print(f"No shares of {stock_name} available to sell.")
                 continue
             while True:
-                tmp : str = input(f"Enter the quantity you want to sell (up to {quantity_available}) (q to quit): ")
+                tmp: str = input(f"Enter the quantity you want to sell (up to "
+                                 f"{quantity_available}) (q to quit): ")
                 try:
+
                     quantity = int(tmp)
                 except ValueError:
                     if tmp == "q":
@@ -174,3 +183,24 @@ class RealPlayer(Player):
                 print("Invalid stock name.")
                 continue
             return stock
+
+    def choose_go_investment_amount(self, go_stock: GoldenOpportunityStock) -> float:
+        print("Golden Opportunity:")
+        print(go_stock)
+        print()
+        while True:
+            print(f"Your Capital: {self.capital}\n")
+            input_str: str = input("How much would you like to invest?: ")
+            invest_amt: float
+
+            try:
+                invest_amt = float(input_str)
+            except ValueError:
+                print("Input must be a number")
+                continue
+
+            if invest_amt < 0 or invest_amt > self.capital:
+                print(f"Input must be in range 0-{self.capital}")
+                continue
+
+            return invest_amt

--- a/stock_market/__init__.py
+++ b/stock_market/__init__.py
@@ -1,1 +1,2 @@
 from .stock_market import StockMarket
+from .stock import Stock

--- a/stock_market/stock_market.py
+++ b/stock_market/stock_market.py
@@ -89,7 +89,7 @@ class StockMarket:
             pad = " "*padding
             coloredheader = f"{YELLOW}${stock.price:.2f} {RESET}" + f"|" + \
                 leftpadding + coloredchange + rightpadding + \
-                    "|" + f" {coloredtotchange}"
+                "|" + f" {coloredtotchange}"
             print(f"{s}{pad}{coloredheader}")
         print("")
         print(f"Total available shares in the market: {self.availableshares}\n")

--- a/team.py
+++ b/team.py
@@ -8,3 +8,10 @@ class Team:
         self.players: list[Player] = players
         for player in self.players:
             player.setTeam(self)
+        self.go_stocks: list = []
+
+    def get_total_capital(self):
+        total_capital: float = 0
+        for player in self.players:
+            total_capital += player.capital
+        return total_capital

--- a/turn/__init__.py
+++ b/turn/__init__.py
@@ -1,0 +1,4 @@
+from .turn import Turn
+from .build_turn import BuildTurn
+from .golden_opportunity_turn import GoldenOpportunityTurn
+from .run_turns import run_turns

--- a/turn/build_turn.py
+++ b/turn/build_turn.py
@@ -9,14 +9,10 @@ from stock_market.stock_market import StockMarket
 class BuildTurn(Turn):
     def __init__(self, teams: list[Team], stock_market: StockMarket) -> None:
         self.name: str = "Build Turn"
-        self.turn_number: int = 1
         self.teams: list[Team] = teams
         self.stock_market: StockMarket = stock_market
 
-    def run(self) -> None:
-        
-        
-        
+    def run(self, turn_number: int) -> None:
         self.stock_market.fluctuate_market()
         for team in self.teams:
             for player in team.players:
@@ -32,7 +28,7 @@ class BuildTurn(Turn):
                 ]
 
                 while True:
-                    self.output()
+                    self.output(turn_number)
                     print(f"[{team.name}] {player.name}'s Turn")
 
                     action: Action = player.choose_action(actions, 2)
@@ -45,5 +41,3 @@ class BuildTurn(Turn):
 
                     if action.one_time is True:
                         actions.remove(action)
-
-        self.turn_number += 1

--- a/turn/golden_opportunity_turn.py
+++ b/turn/golden_opportunity_turn.py
@@ -1,0 +1,56 @@
+import random
+from stock_market import StockMarket
+from team import Team
+from turn import Turn
+from player import Player
+
+# range of percentages for golden opportunity stock price
+TEAM_CAP_PERC_RANGE = 0.2, 0.4
+
+
+class GoldenOpportunityTurn(Turn):
+    def __init__(self, teams: list[Team], stock_market: StockMarket) -> None:
+        self.name: str = "Golden Opportunity Turn"
+        self.teams: list[Team] = teams
+        self.stock_market: StockMarket = stock_market
+
+    def run(self, turn_number: int) -> None:
+        for team in self.teams:
+            # require investment based on percentage of team capital
+            percentage: float = random.uniform(
+                TEAM_CAP_PERC_RANGE[0], TEAM_CAP_PERC_RANGE[1])
+            stock_price: float = team.get_total_capital() * percentage
+
+            go_stock = GoldenOpportunityStock("?", "????", stock_price)
+            investment_needed: float = 10000
+            team_total_investment: float = 0
+            player_investments: dict[Player, float] = {}
+            for player in team.players:
+                print(player.name)
+                self.output(turn_number)
+                player_investment: float = player.choose_go_investment_amount(
+                    go_stock)
+                player_investments[player] = player_investment
+                team_total_investment += player_investment
+
+            if team_total_investment < investment_needed:
+                print("Investment unsuccessful\n")
+            else:
+                print("Investment successful\n")
+                # take capital from players
+                for player, investment_amt in player_investments.items():
+                    player.capital -= investment_amt
+
+                # add stock to team portfolio
+                team.go_stocks.append(go_stock)
+
+
+class GoldenOpportunityStock():
+    def __init__(self, name: str, ticker: str, price: float):
+        self.name: str = name
+        self.ticker: str = ticker
+        self.price: float = price
+
+    def __str__(self):
+        return f"\nName: {self.name}\n" + \
+            f"Ticker: {self.ticker}\n"

--- a/turn/run_turns.py
+++ b/turn/run_turns.py
@@ -1,0 +1,11 @@
+from turn import Turn
+
+
+def run_turns(turns: list[list[Turn, int]]):
+    turn_number: int = 1
+    for t in turns:
+        turn: Turn = t[0]
+        n: int = t[1]
+        for i in range(turn_number, turn_number + n):
+            turn.run(i)
+        turn_number += n

--- a/turn/turn.py
+++ b/turn/turn.py
@@ -1,10 +1,9 @@
 class Turn():
     def __init__(self) -> None:
         self.name: str
-        self.turn_number: int
 
-    def run(self) -> None:
+    def run(self, turn_number: int) -> None:
         raise NotImplementedError()
 
-    def output(self) -> None:
-        print(f"---- {self.name}: Turn {self.turn_number} ----")
+    def output(self, turn_number: int) -> None:
+        print(f"---- {self.name}: Turn {turn_number} ----")


### PR DESCRIPTION
## Description
Added golden opportunity turn and made some changes to how the game runs turns. For now they don't have names or tickers and they're separate from normal stocks. When the purchase is successful the stock is added to the team's golden opportunity stocks. The required investment amount is calculated based on a percentage of the team's total capital, and the percentage range can be changed.

## Changes Made
- add golden opportunity turns
- make it easier to specify sequence and amount of turns to run

## Testing
- [ ] comment line 40 in main.py and run to try the golden opportunity turn